### PR TITLE
Fixed Shadow gets cut off on FAB

### DIFF
--- a/example/src/main/res/layout/fragment_circle_menu.xml
+++ b/example/src/main/res/layout/fragment_circle_menu.xml
@@ -3,6 +3,7 @@
     xmlns:fab="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipChildren="false"
     android:background="@android:color/white">
 
     <com.novaapps.floatingactionmenu.FloatingActionMenu

--- a/example/src/main/res/layout/fragment_line_menu.xml
+++ b/example/src/main/res/layout/fragment_line_menu.xml
@@ -3,6 +3,7 @@
     android:orientation="vertical" android:layout_width="match_parent"
     xmlns:fab="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent"
+    android:clipChildren="false"
     android:background="@android:color/holo_green_light">
 
     <com.novaapps.floatingactionmenu.FloatingActionMenu


### PR DESCRIPTION
The solution is here: http://stackoverflow.com/a/35324991. 
Adding `android:clipChildren="false"` property on LinearLayouts for each fragment.
